### PR TITLE
Attach GUIs to Maya window

### DIFF
--- a/kiko/python/kiko/apps/maya/mayafacade.py
+++ b/kiko/python/kiko/apps/maya/mayafacade.py
@@ -18,12 +18,15 @@ import math
 import warnings
 import tempfile
 
+from shiboken2 import wrapInstance
+from maya import OpenMayaUI as omui
 from maya import OpenMaya, OpenMayaAnim
 from maya import cmds
 
 from kiko.constants import APPS, KIKO_PREVIEW_MAXIMUM_SIZE
 from kiko.exceptions import FacadeRuntimeError, FacadeWarning
 from kiko.apps.basefacade import BaseFacade
+from kiko.ui.qthandler import QtWidgets
 
 from .constants import (MAYA_TO_KIKO_CHANNELS, KIKO_TO_MAYA_CHANNELS, FPS,
                         KIKO_TO_MAYA_INFINITY_BEHAVIOR,
@@ -282,6 +285,13 @@ class MayaFacadeHelper(object):
                 vector[i] = OpenMaya.MDistance(vector[i]).asUnits(
                                                OpenMaya.MDistance.uiUnit())
         return vector
+
+    @staticmethod
+    def get_main_window():
+        main_window_ptr = omui.MQtUtil.mainWindow()
+        main_window = wrapInstance(long(main_window_ptr), QtWidgets.QMainWindow)
+
+        return main_window
 
 class MayaFacade(BaseFacade):
 

--- a/kiko/python/kiko/apps/maya/mayafacade.py
+++ b/kiko/python/kiko/apps/maya/mayafacade.py
@@ -18,7 +18,6 @@ import math
 import warnings
 import tempfile
 
-from shiboken2 import wrapInstance
 from maya import OpenMayaUI as omui
 from maya import OpenMaya, OpenMayaAnim
 from maya import cmds
@@ -26,7 +25,7 @@ from maya import cmds
 from kiko.constants import APPS, KIKO_PREVIEW_MAXIMUM_SIZE
 from kiko.exceptions import FacadeRuntimeError, FacadeWarning
 from kiko.apps.basefacade import BaseFacade
-from kiko.ui.qthandler import QtWidgets
+from kiko.ui.qthandler import QtWidgets, shiboken
 
 from .constants import (MAYA_TO_KIKO_CHANNELS, KIKO_TO_MAYA_CHANNELS, FPS,
                         KIKO_TO_MAYA_INFINITY_BEHAVIOR,
@@ -289,7 +288,7 @@ class MayaFacadeHelper(object):
     @staticmethod
     def get_main_window():
         main_window_ptr = omui.MQtUtil.mainWindow()
-        main_window = wrapInstance(long(main_window_ptr), QtWidgets.QMainWindow)
+        main_window = shiboken.wrapInstance(long(main_window_ptr), QtWidgets.QMainWindow)
 
         return main_window
 

--- a/kiko/python/kiko/apps/maya/mayafacade.py
+++ b/kiko/python/kiko/apps/maya/mayafacade.py
@@ -556,7 +556,7 @@ class MayaFacade(BaseFacade):
     @staticmethod
     def move_to_frame(frame):
         anim_control = OpenMayaAnim.MAnimControl()
-        anim_control.setCurrentTime(OpenMaya.MTime(frame))
+        anim_control.setCurrentTime(OpenMaya.MTime(frame, OpenMaya.MTime.uiUnit()))
 
     @staticmethod
     def get_active_frame_range():

--- a/kiko/python/kiko/apps/maya/ui/exporter.py
+++ b/kiko/python/kiko/apps/maya/ui/exporter.py
@@ -13,9 +13,10 @@
 # ==============================================================================
 
 
-from kiko.ui.qthandler import QtWidgets
+from kiko.ui.qthandler import QtWidgets, QtCore
 
 from kiko.apps.maya import manager
+from kiko.apps.maya.mayafacade import MayaFacadeHelper
 from kiko.apps.maya.mayapreferences import MayaPreferences
 from kiko.ui.exporter import KikoExporterDialog
 from kiko.ui.mixed import create_box_layout, ORIENTATION
@@ -60,5 +61,5 @@ class MayaExporterDialog(KikoExporterDialog):
         super(MayaExporterDialog, self).__init__(manager.MayaKikoManager(),
                             app_preference_widget=MayaExporterPreferences())
 
-
-
+        self.setParent(MayaFacadeHelper.get_main_window())
+        self.setWindowFlags(QtCore.Qt.Window)

--- a/kiko/python/kiko/apps/maya/ui/importer.py
+++ b/kiko/python/kiko/apps/maya/ui/importer.py
@@ -13,9 +13,10 @@
 # ==============================================================================
 
 
-from kiko.ui.qthandler import QtWidgets
+from kiko.ui.qthandler import QtWidgets, QtCore
 
 from kiko.apps.maya import manager
+from kiko.apps.maya.mayafacade import MayaFacadeHelper
 from kiko.apps.maya.mayapreferences import MayaPreferences
 from kiko.ui.importer import KikoImporterDialog
 from kiko.ui.mixed import create_box_layout, ORIENTATION
@@ -51,5 +52,5 @@ class MayaImporterDialog(KikoImporterDialog):
         super(MayaImporterDialog, self).__init__(manager.MayaKikoManager(),
                             app_preference_widget=MayaImporterPreferences())
 
-
-
+        self.setParent(MayaFacadeHelper.get_main_window())
+        self.setWindowFlags(QtCore.Qt.Window)


### PR DESCRIPTION
In response to issue #1 I've added functionality to the MayaFacadeHelper to get a reference to the main Maya window. The exporter and importer set this as the parent. Also setting the WindowFlags as 'Window' to allow for minimizing within Maya.

I went ahead and added in a fix for issue #3 as well. Wasn't sure how you guys prefer to handle individual (but small) changes like this. Unique branches and separate pull requests for each?