### PR TITLE
Make kb format human-readable

### DIFF
--- a/kiko/python/kiko/io/kikofile.py
+++ b/kiko/python/kiko/io/kikofile.py
@@ -59,7 +59,7 @@ class KikoFile(object):
     @classmethod
     def _add_to_tar_from_dict(cls, tar_file, name, data):
         io = StringIO.StringIO()
-        json.dump(data, io)
+        json.dump(data, io, indent=2, sort_keys=True)
         io.seek(0)
         cls._add_to_tar(tar_file, name, io)
 
@@ -96,7 +96,7 @@ class KikoFile(object):
 
     def _save_data_only(self):
         f = open(self._file_path, 'wb')
-        json.dump(self._data, f)
+        json.dump(self._data, f, indent=2, sort_keys=True)
         f.close()
 
     @property


### PR DESCRIPTION
Hi toolchefs,

At the expense of diskspace, make outputted JSON human-readable by indenting and sorting keys.

This one is for discussion, and should not be merged as-is. The space cost is about **5x** that of the original.

- Before: `anim.kb = 60 kb`
- After: `anim.kb = 300 kb`

So likely something better suited for a user-specified option. Default to readable, which is good for beginners and first impression, and editable by studios/power-users looking to optimise.

Thoughts?

**Before**

```json
{"data":{"channels":[],"children":[{"channels":[{"chunks":[{"opD
ata":{"value":0.0},"opName":"StaticOperator","opVer":1,"type
":"Chunk"}],"name":"translateX","type":"Channel"},{"chunks":
[{"opData":{"value":0.0},"opName":"StaticOperator","opVer":
1,"type":"Chunk"}],"name":"translateY","type":"Channel"},{"c
hunks":[{"opData":{"value":0.0},"opName":"StaticOperator","
opVer":1,"type":"Chunk"}],"name":"translateZ","type":"Chann
el"},{"chunks":[{"opData":{"value":0.0},"opName":"StaticOper
ator","opVer":1,"type":"Chunk"}],"name":"rotateX","type":"Ch
annel"},{"chunks":[{"opData":{"value":0.0},"opName":"StaticO
perator","opVer":1,"type":"Chunk"}],"name":"rotateY","type":"
Channel"},{"chunks":[{"opData...
```

**After**

```py
{
  "data": {
    "channels": [], 
    "children": [
      {
        "channels": [
          {
            "chunks": [
              {
                "opData": {
                  "value": 0.0
                }, 
                "opName": "StaticOperator", 
                "opVer": 1, 
                "type": "Chunk"
              }
            ], 
            "name": "translateX", 
            "type": "Channel"
          }, 
          {
            "chunks": [
              {
                "opData": {
                  "value": 0.0
                }, 
                "opName": "StaticOperator", 
                "opVer": 1, 
                "type": "Chunk"
              }
...
```